### PR TITLE
Dev yangqqin

### DIFF
--- a/source/infrastructure/data_connectors/automatic_databrew_job_launch.py
+++ b/source/infrastructure/data_connectors/automatic_databrew_job_launch.py
@@ -121,7 +121,10 @@ class AutomaticDatabrewJobLaunch:
         dynamodb_table_statement = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
             actions=[
-                "dynamodb:*",
+                 "dynamodb:PutItem",
+                 "dynamodb:Query",
+                 "dynamodb:UpdateItem",
+                 "dynamodb:GetItem",
             ],
             resources=[
                 f"arn:aws:dynamodb:*:{stack_account}:table/{dynamodb_table_name}/stream/*",

--- a/source/infrastructure/data_connectors/base_connector_stack.py
+++ b/source/infrastructure/data_connectors/base_connector_stack.py
@@ -27,9 +27,6 @@ from data_connectors.connector_buckets import ConnectorBuckets
 from data_connectors.transform.databrew_transform import DataBrewTransform
 from data_connectors.automatic_databrew_job_launch import AutomaticDatabrewJobLaunch
 from data_connectors.orchestration.stepfunctions.base import WorkflowOrchestrator
-from data_connectors.orchestration.async_callback_construct import (
-    AsyncCallbackConstruct,
-)
 
 
 class BaseConnectorStack(SolutionStack):
@@ -127,10 +124,6 @@ class BaseConnectorStack(SolutionStack):
         subclass of the orchestration workflow construct
         Override from BaseConnectorStack
         """
-        async_callback_construct = AsyncCallbackConstruct(
-            self, "WorkflowOrchestration", self.transform.recipe_job_name
-        )
-        
         return WorkflowOrchestrator(
             self,
             "WorkflowOrchestrator",
@@ -139,7 +132,6 @@ class BaseConnectorStack(SolutionStack):
             self.transform.dataset_name,
             self.transform.transform_recipe_file_location_parameter.value_as_string,
             self.transform.recipe_job_name,
-            async_callback_construct.brew_run_job_lambda,
             self.sns_topic,
             self.dynamodb_table,
             self.transform.recipe_lambda_custom_resource,

--- a/source/infrastructure/data_connectors/orchestration/stepfunctions/workflows/salesforce_workflow.py
+++ b/source/infrastructure/data_connectors/orchestration/stepfunctions/workflows/salesforce_workflow.py
@@ -27,14 +27,21 @@ from data_connectors.orchestration.stepfunctions.base import WorkflowOrchestrato
 class SalesforceWorkflow(WorkflowOrchestrator):
     """Ingests reddit records into S3"""
 
-    def __init__(self, scope: Construct, id: str, connector_update_lambda, appflow_resource, appflow_launch_state_machine_name, *args):
+    def __init__(
+            self,
+            scope: Construct,
+            id: str,
+            connector_update_lambda,
+            appflow_resource,
+            appflow_launch_state_machine_name,
+            *args
+    ):
         self.connector_update_lambda = connector_update_lambda
         self.appflow_resource = appflow_resource
         self.appflow_launch_state_machine_name = appflow_launch_state_machine_name
         super().__init__(scope, id, *args)
 
         log_group_name = f"/aws/vendedlogs/states/{Aws.STACK_NAME}-Appflow-{Fn.select(2, Fn.split('/', Aws.STACK_ID))}"
-
 
         self.appflow_launch_state_machine = sfn.StateMachine(
             self,
@@ -62,7 +69,9 @@ class SalesforceWorkflow(WorkflowOrchestrator):
             parameters={
                 "FlowName": self.appflow_resource.flow_name,
             },
-            iam_resources=["*"],
+            iam_resources=[
+                f"arn:{Aws.PARTITION}:appflow:{Aws.REGION}:{Aws.ACCOUNT_ID}:flow/{self.appflow_resource.flow_name}",
+            ],
         )
 
         return sfn.Chain.start(self.invoke_connector_update_lambda().next(start_appflow))

--- a/source/infrastructure/data_connectors/salesforce_pull_stack.py
+++ b/source/infrastructure/data_connectors/salesforce_pull_stack.py
@@ -468,7 +468,7 @@ class SalesforceMarketingCloudStack(AppFlowPullStack):
     def add_cdk_nag_suppressions(self):
         nag_suppression_reason_for_wildcard_permissions = "The IAM entity contains wildcard permissions"
         for path in [
-            f"/SalesforceMarketingCloudStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource",
+            "/SalesforceMarketingCloudStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource",
         ]:
             NagSuppressions.add_resource_suppressions_by_path(
                 self,

--- a/source/infrastructure/data_connectors/salesforce_pull_stack.py
+++ b/source/infrastructure/data_connectors/salesforce_pull_stack.py
@@ -29,7 +29,6 @@ from data_connectors.aws_lambda import LAMBDA_PATH
 from data_connectors.aws_lambda.layers.aws_solutions.layer import SolutionsLayer
 
 from data_connectors.appflow_pull_stack import AppFlowPullStack
-from data_connectors.orchestration.async_callback_construct import AsyncCallbackConstruct
 from data_connectors.orchestration.stepfunctions.workflows.salesforce_workflow import SalesforceWorkflow
 
 
@@ -469,7 +468,7 @@ class SalesforceMarketingCloudStack(AppFlowPullStack):
     def add_cdk_nag_suppressions(self):
         nag_suppression_reason_for_wildcard_permissions = "The IAM entity contains wildcard permissions"
         for path in [
-            "/SalesforceMarketingCloudStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource",
+            f"/SalesforceMarketingCloudStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource",
         ]:
             NagSuppressions.add_resource_suppressions_by_path(
                 self,
@@ -578,10 +577,6 @@ class SalesforceMarketingCloudStack(AppFlowPullStack):
         )
 
     def create_workflow_deferred(self):
-        async_callback_construct = AsyncCallbackConstruct(
-            self, "SalesforceWorkflowOrchestration",
-            self.transform.recipe_job_name)
-
         self.appflow_launch_state_machine_name = f"{Aws.STACK_NAME}-AppflowLaunch"
         return SalesforceWorkflow(
             self, "SalesforceWorkflow",
@@ -593,7 +588,6 @@ class SalesforceMarketingCloudStack(AppFlowPullStack):
             self.transform.dataset_name, self.transform.
             transform_recipe_file_location_parameter.value_as_string,
             self.transform.recipe_job_name,
-            async_callback_construct.brew_run_job_lambda,
             self.sns_topic,
             self.dynamodb_table,
             self.transform.recipe_lambda_custom_resource_function,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Tighten resources and actions used in IAM policy. 
- Moves the `async_callback_construct` creation from `base_connector_stack` and `salesforce_pull_stack`  into `WorkflowOrchestrator`.
- Fix async_callback_construct tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
