### PR TITLE
Databrew job error handling in S3 trigger workflow

### DIFF
--- a/source/aws_lambda/shared/util/shared/stepfunctions/__init__.py
+++ b/source/aws_lambda/shared/util/shared/stepfunctions/__init__.py
@@ -28,7 +28,7 @@ def send_task_success(output: str, task_token: str, service_client: botocore.cli
         service_client.send_task_success(output=output, taskToken=task_token)
     except ClientError as error:
         logger.error(
-            f"Error ocurred when sending task success status for output: {output} and taskToken: {task_token}. Following error occured: {str(error)}. Sending task failure"
+            f"Error ocurred when sending task success status for output: {output} and taskToken: {task_token}. Following error occurred: {str(error)}. Sending task failure"
         )
         send_task_failure(error, task_token, service_client=service_client)
         raise error
@@ -45,7 +45,7 @@ def send_task_failure(error: Exception, task_token: str, service_client: botocor
         )
     except ClientError as cli_error:
         logger.error(
-            f"Failure to send error status to stepfunction for taskToken {task_token}. Following error occured {str(cli_error)}"
+            f"Failure to send error status to stepfunction for taskToken {task_token}. Following error occurred {str(cli_error)}"
         )
         raise cli_error
 
@@ -58,5 +58,5 @@ def send_heart_beat(task_token: str, service_client: botocore.client.BaseClient 
         service_client.send_task_heartbeat(taskToken=task_token)
     except ClientError as cli_error:
         logger.error(
-            f"Error occured when sending heart beat for task {task_token}. Following error occured: {str(cli_error)}. Will not send failure notice"
+            f"Error occured when sending heart beat for task {task_token}. Following error occurred: {str(cli_error)}. Will not send failure notice"
         )

--- a/source/infrastructure/data_connectors/base_connector_stack.py
+++ b/source/infrastructure/data_connectors/base_connector_stack.py
@@ -26,7 +26,7 @@ from aws_solutions.cdk.stack import SolutionStack
 from data_connectors.connector_buckets import ConnectorBuckets
 from data_connectors.transform.databrew_transform import DataBrewTransform
 from data_connectors.automatic_databrew_job_launch import AutomaticDatabrewJobLaunch
-from data_connectors.orchestration.stepfunctions.base import WorkflowOrchestrator
+from data_connectors.orchestration.stepfunctions.workflow_orchestrator import WorkflowOrchestrator
 
 
 class BaseConnectorStack(SolutionStack):

--- a/source/infrastructure/data_connectors/orchestration/stepfunctions/workflow_orchestrator.py
+++ b/source/infrastructure/data_connectors/orchestration/stepfunctions/workflow_orchestrator.py
@@ -12,11 +12,17 @@
 # ######################################################################################################################
 
 
-from aws_cdk import aws_stepfunctions as sfn
-from aws_cdk import aws_stepfunctions_tasks as tasks
 from constructs import Construct
-from aws_cdk import Aws, Fn
+from aws_cdk import (
+    Aws,
+    Fn,
+    CustomResource,
+    aws_stepfunctions as sfn,
+    aws_stepfunctions_tasks as tasks
+)
+from aws_cdk.aws_sns import Topic
 from aws_cdk.aws_logs import LogGroup
+from aws_cdk.aws_dynamodb import Table
 from cdk_nag import NagSuppressions
 from data_connectors.orchestration.async_callback_construct import AsyncCallbackConstruct
 
@@ -28,14 +34,14 @@ class WorkflowOrchestrator(Construct):
             self,
             scope: Construct,
             id: str,
-            recipe_name,
-            s3_bucket_name,
-            dataset_name,
-            recipe_bucket,
-            recipe_job_name,
-            sns_topic,
-            dynamodb_table,
-            recipe_lambda_custom_resource,
+            recipe_name: str,
+            s3_bucket_name: str,
+            dataset_name: str,
+            recipe_bucket_name: str,
+            recipe_job_name: str,
+            sns_topic: Topic,
+            dynamodb_table: Table,
+            recipe_lambda_custom_resource: CustomResource,
     ):
         """
         Create a new ingestion workflow
@@ -44,7 +50,7 @@ class WorkflowOrchestrator(Construct):
         self.recipe_name = recipe_name
         self.s3_bucket_name = s3_bucket_name
         self.dataset_name = dataset_name
-        self.recipe_bucket = recipe_bucket
+        self.recipe_bucket_name = recipe_bucket_name
         self.recipe_job_name = recipe_job_name
         self.sns_topic = sns_topic
         self.dynamodb_table = dynamodb_table
@@ -97,7 +103,8 @@ class WorkflowOrchestrator(Construct):
 
         file_uploading_pass = sfn.Pass(self, "File Uploading")
 
-        trigger_data_transform_workflow = self.invoke_lambda_run_brew_jobs().next(self.publish_notification())
+        trigger_data_transform_workflow = self.invoke_lambda_run_brew_jobs() \
+            .next(self.publish_brew_job_done_notification())
 
         choice = sfn.Choice(self, "Check File Upload Status")
         choice.when(sfn.Condition.timestamp_less_than_equals_json_path("$.dynamodb_response.Item.timestamp_str.S",
@@ -108,17 +115,6 @@ class WorkflowOrchestrator(Construct):
         state_machine_definition = wait.next(dynamodb_get_item).next(choice)
 
         return state_machine_definition
-
-    def publish_notification(self):
-        """
-        Function to run the tasks to publish the outcome of the step function
-        """
-        return tasks.SnsPublish(self, "Databrew Job Notification",
-            topic=self.sns_topic,
-            integration_pattern=sfn.IntegrationPattern.REQUEST_RESPONSE,
-            message=sfn.TaskInput.from_text("Databrew Job is Done and Orchestration Completed."),
-            subject=sfn.JsonPath.format("Data Connectors for AWS Clean Rooms Notifications: Pipeline result [{}]", sfn.JsonPath.string_at("$.status"))
-        )
 
     def invoke_lambda_run_brew_jobs(self):
         """
@@ -135,6 +131,43 @@ class WorkflowOrchestrator(Construct):
                     "brew_job_name": self.recipe_job_name
                 }
             )
+        ).add_catch(
+            errors=["States.TaskFailed"],
+            handler=self.databrew_job_failure_handler()
+        )
+
+    def databrew_job_failure_handler(self):
+        tasks_chain = self.publish_brew_job_fail_notification()
+        return tasks_chain
+
+    def publish_brew_job_done_notification(self):
+        """
+        Function to run the tasks to publish the outcome of the step function
+        """
+        return tasks.SnsPublish(
+            self, "Databrew Job Done Notification",
+            topic=self.sns_topic,
+            integration_pattern=sfn.IntegrationPattern.REQUEST_RESPONSE,
+            message=sfn.TaskInput.from_text("Databrew Job is Done and Orchestration Completed."),
+            subject=sfn.JsonPath.format(
+                "Data Connectors for AWS Clean Rooms Notifications: Pipeline result [{}]",
+                sfn.JsonPath.string_at("$.status"))
+        )
+
+    def publish_brew_job_fail_notification(self):
+        brew_job_fail_message = sfn.JsonPath.format(
+            "Data Connectors for AWS Clean Rooms Notifications: Databrew Job is Fail and another job is running, "
+            "Error {}, Cause {}",
+            sfn.JsonPath.string_at("$.Error"),
+            sfn.JsonPath.string_at("$.Cause")
+        )
+        return tasks.SnsPublish(
+            self,
+            "Databrew Job Fail Notification",
+            topic=self.sns_topic,
+            integration_pattern=sfn.IntegrationPattern.REQUEST_RESPONSE,
+            message=sfn.TaskInput.from_text(brew_job_fail_message),
+            subject="Data Connectors for AWS Clean Rooms Notifications: Pipeline result [Fail]"
         )
 
     def cdk_nag_suppression(self):

--- a/source/infrastructure/data_connectors/orchestration/stepfunctions/workflow_orchestrator.py
+++ b/source/infrastructure/data_connectors/orchestration/stepfunctions/workflow_orchestrator.py
@@ -122,7 +122,7 @@ class WorkflowOrchestrator(Construct):
         """
 
         return tasks.LambdaInvoke(
-            self, 'Launch Databrew Job',
+            self, 'Launch DataBrew Job',
             lambda_function=self.async_callback_construct.brew_run_job_lambda,
             integration_pattern=sfn.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
             payload=sfn.TaskInput.from_object(
@@ -147,10 +147,10 @@ class WorkflowOrchestrator(Construct):
         message_attributes = self.create_message_attributes('DataBrew', 'DataBrew job is Launched',
                                                             sfn.JsonPath.string_at("$.status"))
         return tasks.SnsPublish(
-            self, "Databrew Job Done Notification",
+            self, "DataBrew Job Launch Success Notification",
             topic=self.sns_topic,
             integration_pattern=sfn.IntegrationPattern.REQUEST_RESPONSE,
-            message=sfn.TaskInput.from_text("Databrew Job is launched and orchestration completed."),
+            message=sfn.TaskInput.from_text("DataBrew Job is launched and orchestration completed."),
             message_attributes=message_attributes,
             subject=sfn.JsonPath.format(
                 "Data Connectors for AWS Clean Rooms Notifications: Pipeline result [{}]",
@@ -159,14 +159,14 @@ class WorkflowOrchestrator(Construct):
 
     def publish_brew_job_fail_notification(self):
         brew_job_fail_message = sfn.JsonPath.format(
-            "Databrew Job fails to launch, error: {}, cause: {}",
+            "DataBrew Job fails to launch, error: {}, cause: {}",
             sfn.JsonPath.string_at("$.Error"),
             sfn.JsonPath.string_at("$.Cause")
         )
         message_attributes = self.create_message_attributes('DataBrew', sfn.JsonPath.string_at("$.Cause"), "Fail")
         return tasks.SnsPublish(
             self,
-            "Databrew Job Fail Notification",
+            "DataBrew Job Launch Fail Notification",
             topic=self.sns_topic,
             integration_pattern=sfn.IntegrationPattern.REQUEST_RESPONSE,
             message=sfn.TaskInput.from_text(brew_job_fail_message),

--- a/source/infrastructure/data_connectors/orchestration/stepfunctions/workflows/salesforce_workflow.py
+++ b/source/infrastructure/data_connectors/orchestration/stepfunctions/workflows/salesforce_workflow.py
@@ -21,7 +21,7 @@ from aws_cdk.aws_logs import LogGroup
 from cdk_nag import NagSuppressions
 from constructs import Construct
 
-from data_connectors.orchestration.stepfunctions.base import WorkflowOrchestrator
+from data_connectors.orchestration.stepfunctions.workflow_orchestrator import WorkflowOrchestrator
 
 
 class SalesforceWorkflow(WorkflowOrchestrator):

--- a/source/tests/infrastructure/data_connectors/orchestration/stepfunctions/test_workflow_orchestrator.py
+++ b/source/tests/infrastructure/data_connectors/orchestration/stepfunctions/test_workflow_orchestrator.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import aws_cdk as cdk
+import pytest
+from aws_cdk.assertions import Match, Template, Capture
+from aws_solutions.cdk import CDKSolution
+from aws_solutions.cdk.stack import SolutionStack
+from data_connectors.orchestration.stepfunctions.workflow_orchestrator import WorkflowOrchestrator
+from aws_cdk.aws_sns import Topic
+import aws_cdk.aws_dynamodb as dynamodb
+from aws_cdk.aws_dynamodb import Table
+from aws_cdk import CustomResource
+
+
+@pytest.fixture(scope="module")
+def mock_solution():
+    path = Path(__file__).parent / ".." / ".." / "cdk.json"
+    return CDKSolution(cdk_json_path=path)
+
+
+@pytest.fixture(scope="module")
+def synth_template(mock_solution):
+    app = cdk.App(context=mock_solution.context.context)
+    stack = SolutionStack(app,
+                          "TestWorkflowOrchestrator",
+                          description="Empty Stack for Testing",
+                          template_filename="test-workflow-orchestrator.template")
+
+    mock_sns_topic = Topic(stack, "UnitTestTopic")
+    mock_dynamodb_table = Table(stack,
+                                "UnitTestDynamodbTable",
+                                partition_key=dynamodb.Attribute(name="watching_key",
+                                                                 type=dynamodb.AttributeType.STRING)
+                                )
+    mock_custom_resource = CustomResource(stack, "UnitTestRecipeCustomResource", service_token="UnitTestServiceToken")
+
+    WorkflowOrchestrator(
+        stack, "TestWorkflowOrchestrator",
+        recipe_name="UnitTestRecipe",
+        s3_bucket_name="UnitTestS3Bucket",
+        dataset_name="UnitTestDataset",
+        recipe_bucket_name="UnitTestRecipeBucket",
+        recipe_job_name="UnitTestRecipeJob",
+        sns_topic=mock_sns_topic,
+        dynamodb_table=mock_dynamodb_table,
+        recipe_lambda_custom_resource=mock_custom_resource
+    )
+    synth_template = Template.from_stack(stack)
+    yield synth_template
+
+
+def test_base_workflow_creation(synth_template):
+    synth_template.resource_count_is("AWS::StepFunctions::StateMachine", 1)
+
+
+def test_invoke_lambda_run_brew_jobs_creation(synth_template):
+    role_definition_capture = Capture()
+    states_definition_capture = Capture()
+    synth_template.has_resource_properties(
+        "AWS::StepFunctions::StateMachine",
+        {
+            "RoleArn": {
+                "Fn::GetAtt": [role_definition_capture, "Arn"]
+            },
+            "DefinitionString": states_definition_capture,
+        }
+    )
+    states_definition = str(states_definition_capture.as_object()['Fn::Join'][1])
+
+    payload = "\"Payload\":{\"task_token.$\":\"$$.Task.Token\",\"brew_job_name\":\"UnitTestRecipeJob\"}"
+    assert payload in states_definition
+
+    on_catch = "\"Catch\":[{\"ErrorEquals\":[\"States.TaskFailed\"],\"Next\":\"Databrew Job Fail Notification\"}]"
+    assert on_catch in states_definition


### PR DESCRIPTION
*Issue #, if available:*

If a brew job is triggered while another job is running, state machine execution (`States.TaskFailed`) fails as DataBrew only allow one running at a time for a particular job. 

*Description of changes:*
- Add DataBrew job error handling in S3 trigger workflow
   - The `Launch Brew Job` task catches `States.TaskFailed` error, then enter `Databrew Job Fail Notification` task to send a databrew job fail notification email. 
- Add unit tests for S3 trigger workflow
   - Test generated template

*S3 trigger workflow behaviour for `Launch Brew Job` task:*
- If brew job is successfully launched, enter `Databrew Job Done Notification` task sending a databrew job is done email. If brew job is fail to launch, enter `Databrew Job Fail Notification` task sending a databrew job is fail email. In both case, the workflow finally enter `Pass` and mark its execution status as succeed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
