### PR TITLE
Revert "Upgrade cdk version"

### DIFF
--- a/source/infrastructure/deploy.py
+++ b/source/infrastructure/deploy.py
@@ -50,8 +50,8 @@ def build_app(context):
             stack.name,
             description=stack.description,
             template_filename=stack.template_filename,
+            synthesizer=synthesizer(),
         )
-        synthesizer().bind(stk)
         Aspects.of(app).add(AwsSolutionsChecks())
         Aspects.of(app).add(AppRegistry(stk, f'AppRegistry-{stack.name}'))
     return app.synth(validate_on_synthesis=True, skip_validation=False)

--- a/source/requirements-dev.txt
+++ b/source/requirements-dev.txt
@@ -2,7 +2,7 @@ avro==1.11.1
 wheel
 black
 boto3
-aws_cdk_lib>=2.62.0
+aws_cdk_lib~=2.59.0
 aws_solutions_constructs.aws_lambda_sns~=2.25.0
 aws_solutions_constructs.aws_eventbridge_lambda~=2.25.0
 aws_solutions_constructs.aws_lambda_dynamodb~=2.25.0


### PR DESCRIPTION
Reverts upgrading `aws_cdk_lib` to 2.63.0 due to the `cdk_solution_helper_py` synthesizers. 