### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.1] - 2023-08-15
 
+- [Fix vulnerability alerts in v1.2.0 reported by Dependabot [#55](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/issues/55)]
+- [Dependabot: Unintended leak of Proxy-Authorization header in requests [#50](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/security/dependabot/2) [#51](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/security/dependabot/1) [#52](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/security/dependabot/3) [#53](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/security/dependabot/4) [#54](https://github.com/aws-solutions/data-connectors-for-aws-clean-rooms/security/dependabot/5)]
 - Upgrade ``requests`` library to version 2.31.0 to fix vulnerability reported by Dependabot
 - Modify Access logging bucket object ownership to Bucket owner preferred
 - Add SQS-managed encryption to SQS queue in the solution
 - Add new constant for duplicated IAM message string
+
+## [1.2.2] - 2023-10-23
+
+- Upgrade ``avro`` library to version 1.11.3 to fix vulnerability reported by Dependabot
+- Upgrade ``urllib3`` to version 1.26.18 to solve the security vulnerabilities

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -18,7 +18,7 @@ This software includes third party software subject to the following copyrights:
  PyYAML                                           6.0        MIT License
  Werkzeug                                         2.1.2      BSD License
  attrs                                            22.1.0     MIT License
- avro                                             1.11.1     Apache Software License
+ avro                                             1.11.3     Apache Software License
  aws-cdk-lib                                      2.51.0     Apache-2.0
  aws-cdk.asset-awscli-v1                          2.2.11     Apache-2.0
  aws-cdk.asset-kubectl-v20                        2.1.1      Apache-2.0
@@ -79,7 +79,7 @@ This software includes third party software subject to the following copyrights:
  tomli                                            2.0.1      MIT License
  typeguard                                        2.13.3     MIT License
  typing_extensions                                4.4.0      Python Software Foundation License
- urllib3                                          1.26.12    MIT License
+ urllib3                                          1.26.18    MIT License
  websocket-client                                 1.4.2      Apache Software License
  wrapt                                            1.14.1     BSD License
  xmltodict                                        0.13.0     MIT License

--- a/source/cdk_solution_helper_py/helpers_cdk/aws_solutions/cdk/aws_lambda/cfn_custom_resources/solutions_metrics/src/custom_resources/requirements.txt
+++ b/source/cdk_solution_helper_py/helpers_cdk/aws_solutions/cdk/aws_lambda/cfn_custom_resources/solutions_metrics/src/custom_resources/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.31.0
 crhelper==2.0.6
-urllib3<2
+urllib3>=1.26.18, <2.0.0

--- a/source/requirements-dev.txt
+++ b/source/requirements-dev.txt
@@ -1,4 +1,4 @@
-avro==1.11.1
+avro==1.11.3
 wheel
 black
 boto3


### PR DESCRIPTION
*Description of changes:*
- Upgrade `avro` library to version `1.11.3` to address Dependabot security alert
- Upgrade `urllib3` library to version `1.26.18` for security update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
